### PR TITLE
Fix comment typo in pipeline.tf

### DIFF
--- a/pipeline.tf
+++ b/pipeline.tf
@@ -154,7 +154,7 @@ POLICY
 
 }
 
-# S3 Bucket stores meta data of whole pipline stages 
+# S3 Bucket stores meta data of whole pipeline stages 
 resource "aws_s3_bucket" "pipeline" {
   bucket = "hello-app-pipeline-${data.aws_caller_identity.current.account_id}"
   acl    = "private"


### PR DESCRIPTION
## Summary
- fix typo in comment above the pipeline S3 bucket

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685397949ad0832d8bb544c960c120a7